### PR TITLE
Check visibility of container within updateHeight.

### DIFF
--- a/markdownx/static/markdownx/js/markdownx.js
+++ b/markdownx/static/markdownx/js/markdownx.js
@@ -32,7 +32,7 @@
             };
 
             var updateHeight = function() {
-                if (isMarkdownxEditorResizable) {
+                if (isMarkdownxEditorResizable && markdownxEditor.is(":visible")) {
                     markdownxEditor.innerHeight(markdownxEditor.prop('scrollHeight'));
                 }
             };


### PR DESCRIPTION
If a form widget is rendered inside a hidden container (for example an un-focused tab in bootstrap), the scrollHeight is 0. When focus is restored to the widget it doesn't take on the new height of the container, resulting in a thing text area.

Changing updateHeight to check if markdownxEditor is visible appears to resolve this.