### PR TITLE
Add compatibility with Django 2.0.

### DIFF
--- a/markdownx/widgets.py
+++ b/markdownx/widgets.py
@@ -95,9 +95,9 @@ class MarkdownxWidget(forms.Textarea):
         return attrs
 
     class Media:
-        js = {
+        js = [
             'markdownx/js/markdownx{}.js'.format(minified),
-        }
+        ]
 
 
 class AdminMarkdownxWidget(MarkdownxWidget, widgets.AdminTextareaWidget):
@@ -107,9 +107,9 @@ class AdminMarkdownxWidget(MarkdownxWidget, widgets.AdminTextareaWidget):
     """
     class Media:
         css = {
-            'all': {'markdownx/admin/css/markdownx{}.css'.format(minified), }
+            'all': ['markdownx/admin/css/markdownx{}.css'.format(minified)]
         }
 
-        js = {
+        js = [
             'markdownx/js/markdownx{}.js'.format(minified),
-        }
+        ]


### PR DESCRIPTION
Django 2.0 calls `reversed` on the `js` attribute that defines JavaScript resources.

This fails because a `set` cannot be reversed.

With this change, django-markdownx passes a smoke test on Django 2.0.