### PR TITLE
Reset image stream position after using tell

### DIFF
--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -1,5 +1,5 @@
 # Python internal library.
-from os import path, SEEK_END
+from os import path, SEEK_END, SEEK_SET
 from uuid import uuid4
 from collections import namedtuple
 
@@ -63,6 +63,7 @@ class ImageForm(forms.Form):
             # may be stored as uploaded.
             image = self._process_raster(image, image_extension)
             image_size = image.tell()
+            image.seek(0, SEEK_SET)
 
         # Processed file (or the actual file in the case of SVG) is now
         # saved in the memory as a Django object.


### PR DESCRIPTION
For uploads, I noticed that using django-markdownx with something like django-storages doesn't work because the image stream position is set to the end of the steam when the `InMemoryUploadedFile` is instantiated. Simply resetting the image stream position back to the beginning should do the trick.

In the future, when you guys drop Python 2 support, something like [getbuffer](https://docs.python.org/3/library/io.html#io.BytesIO.getbuffer) or [getvalue](https://docs.python.org/3/library/io.html#io.BytesIO.getvalue) could be used to get the length of the buffer instead of using `tell`.