### PR TITLE
Handle csrf stored in sessions

### DIFF
--- a/static-src/markdownx/js/utils.ts
+++ b/static-src/markdownx/js/utils.ts
@@ -122,8 +122,6 @@ export function preparePostData(data: Object, csrf: Boolean=true) {
         if (!csrfToken) csrfToken = (<HTMLInputElement>document.querySelector("input[name='csrfmiddlewaretoken']")).value;
         form.append("csrfmiddlewaretoken", csrfToken);
     }
-    
-    if (csrf) form.append("csrfmiddlewaretoken", getCookie('csrftoken'));
 
     Object.keys(data).map(key => form.append(key, data[key]));
 

--- a/static-src/markdownx/js/utils.ts
+++ b/static-src/markdownx/js/utils.ts
@@ -117,6 +117,12 @@ export function preparePostData(data: Object, csrf: Boolean=true) {
 
     let form: FormData = new FormData();
 
+    if (csrf) {
+        let csrfToken = getCookie('csrftoken');
+        if (!csrfToken) csrfToken = (<HTMLInputElement>document.querySelector("input[name='csrfmiddlewaretoken']")).value;
+        form.append("csrfmiddlewaretoken", csrfToken);
+    }
+    
     if (csrf) form.append("csrfmiddlewaretoken", getCookie('csrftoken'));
 
     Object.keys(data).map(key => form.append(key, data[key]));


### PR DESCRIPTION
This allow to use CSRF_USE_SESSIONS = True which store crsf token in session instead of cookies.
It checks if csrf token found in cookies otherwise try to get csrf token in session.