### PR TITLE
Fixed Travis MacOS build failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,8 @@ matrix:
 # system architecture, OSX tests will only run on one Python 3 + latest stable
 # release for Django.
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update                ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3       ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then virtualenv venv -p python3 ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source venv/bin/activate   ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then python3 -m venv env        ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source env/bin/activate   ; fi
 
 install:
   - python dev.py -no-container


### PR DESCRIPTION
Error: python 2.7.14 is already installed
To upgrade to 3.6.5, run `brew upgrade python`