### PR TITLE
Fix typo on contribution guide

### DIFF
--- a/docs-src/contribution.rst
+++ b/docs-src/contribution.rst
@@ -132,6 +132,7 @@ container of choice, follow these instructions:
 |                         | - bootstrap.sh                     |  - docker-compose.yml              |
 |                         | - runtests.py                      |  - runtests.py                     |
 |                         | - manage.py                        |  - manage.py                       |
+|                         | - package.json                     |  - package.json                    |
 |                         |                                    |                                    |
 +-------------------------+------------------------------------+------------------------------------+
 |                         |                                    |                                    |

--- a/docs-src/contribution.rst
+++ b/docs-src/contribution.rst
@@ -137,7 +137,7 @@ container of choice, follow these instructions:
 |                         |                                    |                                    |
 | **Start the container** | .. code-block:: bash               |  .. code-block:: bash              |
 |                         |                                    |                                    |
-|                         |     python3 dev.py --run-vagrant   |      python3 dev.py --run-docker   |
+|                         |     python3 dev.py -run-vagrant    |      python3 dev.py -run-docker    |
 |                         |                                    |                                    |
 +-------------------------+------------------------------------+------------------------------------+
 |                         |                                    |                                    |


### PR DESCRIPTION
In `dev.py`, there are only `-run-docker` and `-run-vagrant` (with one dash).