### PR TITLE
Fix the compiling docs from sphinx to mkdocs

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -48,9 +48,8 @@ DEV_XML_FILE = 'dev.xml'
 XML_FILE_ABSOLUTE_PATH = join_path(BASE_DIR, DEV_XML_FILE)
 
 pypi_packages = {
-    'sphinx',
-    'sphinx-classy-code',
-    'sphinxcontrib-autoanysrc',
+    'mkdocs',
+    'pymdown-extensions',
 }
 
 
@@ -62,9 +61,7 @@ bash_commands = {
         '/srv/django-markdownx/manage.py runserver 0.0.0.0:8000"'
     ),
     'docs': (
-        'cd {}'.format(join_path(BASE_DIR, 'docs-src', '_theme', 'sphinx_rtd_theme')),
-        '{python} setup.py clean install'.format(python=python_path),
-        'cd ../..'
+        'mkdocs build',
     ),
     'docker': (
         'docker-compose build',

--- a/dev.xml
+++ b/dev.xml
@@ -160,37 +160,11 @@ failures = test_runner(
     failfast=False).run_tests(['tests'])
 sys.exit(failures)</contents>
     </file>
-    <file for="docs">
-        <path>Makefile</path>
-        <contents># Minimal makefile for Sphinx documentation
-#
-
-# You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = DjangoMarkdownx
-SOURCEDIR     = docs-src
-BUILDDIR      = docs
-
-# Put it first so that "make" without argument is like "make help".
-help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-
-.PHONY: help Makefile
-
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)</contents>
-    </file>
     <file for="docs"><path>create_docs.sh</path>
         <contents>#!/usr/bin/env bash
 
 # Compile the docs.
-make clean
-make html
-
-mv ./docs/html/* ./docs/
+mkdocs build
 
 # Open in the browser.
 URL="docs/index.html"


### PR DESCRIPTION
* The current way to build document is mkdocs, but dev.py still use sphinx.