### PR TITLE
re-working widget attribute assignment and creation

### DIFF
--- a/markdownx/widgets.py
+++ b/markdownx/widgets.py
@@ -1,3 +1,5 @@
+from copy import copy
+
 from django import VERSION as DJANGO_VERSION
 from django import forms
 from django.template.loader import get_template
@@ -38,12 +40,9 @@ class MarkdownxWidget(forms.Textarea):
         Context for the template in Django 1.10 or below.
         """
         if not is_post_10:
+            # pre 10, django did not use build_attrs, manually updating attrs here
+            attrs.update(self.get_markdownx_attrs(attrs))
             return super(MarkdownxWidget, self).get_context(name, value, attrs)
-
-        try:
-            attrs.update(self.add_markdownx_attrs(attrs))
-        except AttributeError:
-            attrs = self.add_markdownx_attrs(attrs)
 
         return super(MarkdownxWidget, self).get_context(name, value, attrs)
 
@@ -54,13 +53,9 @@ class MarkdownxWidget(forms.Textarea):
         .. Note::
             Not accepting ``renderer`` is deprecated in Django 1.11.
         """
-        attrs.update(self.attrs)
-        attrs.update(self.add_markdownx_attrs(attrs))
 
         if is_post_10:
             return super(MarkdownxWidget, self).render(name, value, attrs, renderer)
-
-        attrs = self.build_attrs(attrs, name=name)
 
         widget = super(MarkdownxWidget, self).render(name, value, attrs)
 
@@ -70,31 +65,39 @@ class MarkdownxWidget(forms.Textarea):
             'markdownx_editor': widget,
         })
 
+    def build_attrs(self, attrs, extra_attrs=dict()):
+        extra_attrs.update(self.get_markdownx_attrs(attrs))
+        return super(MarkdownxWidget, self).build_attrs(attrs, extra_attrs)
+
     @staticmethod
-    def add_markdownx_attrs(attrs):
+    def get_markdownx_attrs(attrs):
         """
-        Setting (X)HTML node attributes.
+        Getting (X)HTML node attributes.
 
         :param attrs: Attributes to be set.
         :type attrs: dict
-        :return: Dictionary of attributes, including the default attributes.
+        :return: Dictionary of markdownx attributes, excluding the default attributes.
         :rtype: dict
         """
-        if 'class' in attrs.keys():
-            attrs['class'] += ' markdownx-editor'
-        else:
-            attrs.update({
-                'class': 'markdownx-editor'
-            })
-
-        attrs.update({
+        default_attrs = {
             'data-markdownx-editor-resizable': MARKDOWNX_EDITOR_RESIZABLE,
             'data-markdownx-urls-path': MARKDOWNX_URLS_PATH,
             'data-markdownx-upload-urls-path': MARKDOWNX_UPLOAD_URLS_PATH,
             'data-markdownx-latency': MARKDOWNX_SERVER_CALL_LATENCY
+        }
+
+        new_attrs = copy(default_attrs)
+        # Remove keys that are already present in supplied attrs as to not override
+        for key, _ in default_attrs.items():
+            if key in attrs:
+                del new_attrs[key]
+
+        existing_classes = attrs.get('class', '')
+        new_attrs.update({
+            'class': existing_classes + ' markdownx-editor'
         })
 
-        return attrs
+        return new_attrs
 
     class Media:
         js = [

--- a/markdownx/widgets.py
+++ b/markdownx/widgets.py
@@ -65,9 +65,14 @@ class MarkdownxWidget(forms.Textarea):
             'markdownx_editor': widget,
         })
 
-    def build_attrs(self, attrs, extra_attrs=dict()):
+    def build_attrs(self, attrs, extra_attrs=dict(), **old_attrs):
         extra_attrs.update(self.get_markdownx_attrs(attrs))
-        return super(MarkdownxWidget, self).build_attrs(attrs, extra_attrs)
+        if is_post_10:
+            return super(MarkdownxWidget, self).build_attrs(attrs, extra_attrs)
+        # Support old method of attaching extra attibutes as kwargs
+        if old_attrs:
+            extra_attrs.update(old_attrs)
+        return super(MarkdownxWidget, self).build_attrs(attrs, **extra_attrs)
 
     @staticmethod
     def get_markdownx_attrs(attrs):


### PR DESCRIPTION
Hey, it's me again! I revisited #137 which was merged a few months ago, thanks! I didn't like the implementation as it felt like there was a lot of bloat in the previous surrounding code. I also noticed an issue where any provided attributes you wished to overwrite were getting knocked out by the default attributes. 

This PR fixes that issue and hopefully also cleans up the code in the widget. I also opted to use the build in 1.10+ `build_attrs` method as part of that cleanup instead of doing our work in the `render` method.