### PR TITLE
Add `MARKDOWNX_UNIQUE_FILENAMES` option

### DIFF
--- a/docs-src/customization.md
+++ b/docs-src/customization.md
@@ -70,6 +70,7 @@ You may place any of the variables outlined in this page in your `settings.py`, 
 * [`MARKDOWNX_URLS_PATH`](#markdownx_urls_path)
 * [`MARKDOWNX_UPLOAD_URLS_PATH`](#markdownx_upload_urls_path)
 * [`MARKDOWNX_MEDIA_PATH`](#markdownx_media_path)
+* [`MARKDOWNX_UNIQUE_FILENAMES`](#markdownx_unique_filenames)
 * [`MARKDOWNX_UPLOAD_MAX_SIZE`](#markdownx_upload_max_size)
 * [`MARKDOWNX_UPLOAD_CONTENT_TYPES`](#markdownx_upload_content_types)
 * [`MARKDOWNX_IMAGE_MAX_SIZE`](#markdownx_image_max_size)
@@ -188,6 +189,11 @@ MARKDOWNX_MEDIA_PATH = 'markdownx/'
 	```
 
 	This ensures that uploaded files are stored in a different directory on the basis of the date on which they are uploaded. So for instance; an image uploaded on the 15th of April 2017 will be stored under ``media/markdownx/2017/4/15/unique_name.png``.
+
+### `MARKDOWNX_UNIQUE_FILENAMES`
+Default: `True`
+
+Set to `False` if you want to preserve the original filenames. Files will be overwritten if the same filename is used.
 
 ### `MARKDOWNX_UPLOAD_MAX_SIZE`
 

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -108,7 +108,7 @@ class ImageForm(forms.Form):
 
         if commit:
             # Remove the file if it exists
-            if default_storage.exists(path):  #os.path.exists(full_path):
+            if default_storage.exists(full_path):  #os.path.exists(full_path):
                 print('Removing: ', full_path)
                 default_storage.delete(full_path)
                 #os.remove(full_path)

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -109,7 +109,7 @@ class ImageForm(forms.Form):
 
         if commit:
             # Remove the file if it exists
-            if self.exists(full_path):
+            if os.path.exists(full_path):
                 os.remove(full_path)
                 print('Removing: ', full_path)
             print('Saving: ', full_path)

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -103,8 +103,8 @@ class ImageForm(forms.Form):
         """
         # Defining a universally unique name for the file
         # to be saved on the disk.
-        unique_file_name = self.get_unique_file_name(file_name)
-        full_path = path.join(MARKDOWNX_MEDIA_PATH, unique_file_name)
+        #unique_file_name = self.get_unique_file_name(file_name)
+        full_path = path.join(MARKDOWNX_MEDIA_PATH, file_name)
 
         if commit:
             default_storage.save(full_path, image)

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -1,4 +1,3 @@
-import os
 # Python internal library.
 from os import path, SEEK_END, SEEK_SET
 from uuid import uuid4
@@ -109,9 +108,11 @@ class ImageForm(forms.Form):
 
         if commit:
             # Remove the file if it exists
-            if os.path.exists(full_path):
-                os.remove(full_path)
+            if default_storage.exists(path):  #os.path.exists(full_path):
                 print('Removing: ', full_path)
+                default_storage.delete(full_path)
+                #os.remove(full_path)
+
             print('Saving: ', full_path)
             default_storage.save(full_path, image)
             return default_storage.url(full_path)

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -18,7 +18,8 @@ from .settings import (
     MARKDOWNX_MEDIA_PATH,
     MARKDOWNX_UPLOAD_CONTENT_TYPES,
     MARKDOWNX_UPLOAD_MAX_SIZE,
-    MARKDOWNX_SVG_JAVASCRIPT_PROTECTION
+    MARKDOWNX_SVG_JAVASCRIPT_PROTECTION,
+    MARKDOWNX_UNIQUE_FILENAMES
 )
 
 
@@ -103,17 +104,16 @@ class ImageForm(forms.Form):
         """
         # Defining a universally unique name for the file
         # to be saved on the disk.
-        #unique_file_name = self.get_unique_file_name(file_name)
-        full_path = path.join(MARKDOWNX_MEDIA_PATH, file_name)
+        if MARKDOWNX_UNIQUE_FILENAMES:
+            unique_file_name = self.get_unique_file_name(file_name)
+            full_path = path.join(MARKDOWNX_MEDIA_PATH, unique_file_name)
+        else:
+            full_path = path.join(MARKDOWNX_MEDIA_PATH, file_name)
+            # Remove the file if it exists
+            if default_storage.exists(full_path):
+                default_storage.delete(full_path)
 
         if commit:
-            # Remove the file if it exists
-            if default_storage.exists(full_path):  #os.path.exists(full_path):
-                print('Removing: ', full_path)
-                default_storage.delete(full_path)
-                #os.remove(full_path)
-
-            print('Saving: ', full_path)
             default_storage.save(full_path, image)
             return default_storage.url(full_path)
 

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -1,3 +1,4 @@
+import os
 # Python internal library.
 from os import path, SEEK_END, SEEK_SET
 from uuid import uuid4
@@ -107,6 +108,11 @@ class ImageForm(forms.Form):
         full_path = path.join(MARKDOWNX_MEDIA_PATH, file_name)
 
         if commit:
+            # Remove the file if it exists
+            if self.exists(full_path):
+                os.remove(full_path)
+                print('Removing: ', full_path)
+            print('Saving: ', full_path)
             default_storage.save(full_path, image)
             return default_storage.url(full_path)
 

--- a/markdownx/settings.py
+++ b/markdownx/settings.py
@@ -59,6 +59,7 @@ MARKDOWNX_UPLOAD_URLS_PATH = _mdx('UPLOAD_URLS_PATH', '/markdownx/upload/')
 #  --------------------
 MARKDOWNX_MEDIA_PATH = _mdx('MEDIA_PATH', 'markdownx/')
 
+MARKDOWNX_UNIQUE_FILENAMES = True
 
 # Image
 # --------------------


### PR DESCRIPTION
In my application, I needed to maintain the original filenames. I've added an `MARKDOWNX_UNIQUE_FILENAMES` option to allow users to use original filenames. This allows users to overwrite existing files.