### PR TITLE
Remove dependency from django.utils.six

### DIFF
--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -3,9 +3,13 @@ from os import path, SEEK_END, SEEK_SET
 from uuid import uuid4
 from collections import namedtuple
 
+try:
+    from StringIO import StringIO as BytesIO
+except ImportError:
+    from io import BytesIO
+
 # Django library.
 from django import forms
-from django.utils.six import BytesIO
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
 


### PR DESCRIPTION
This dependency is used only for one import, which is now included with
different sources for Python 2.x and 3.x, respectively.

With Python 3, the StringIO module is gone and all functionality is
included in io
(See https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit )

This PR closes #162 