### PR TITLE
Adds support for callable MARKDOWNX_MEDIA_PATH

### DIFF
--- a/docs-src/customization.md
+++ b/docs-src/customization.md
@@ -178,7 +178,7 @@ MARKDOWNX_MEDIA_PATH = 'markdownx/'
 	```python
 	from datetime import datetime
 
-    MARKDOWNX_MEDIA_PATH = datetime.now().strftime('markdownx/%Y/%m/%d')
+    MARKDOWNX_MEDIA_PATH = lambda: datetime.now().strftime('markdownx/%Y/%m/%d')
 	```
 
 	This ensures that uploaded files are stored in a different directory on the basis of the date on which they are uploaded. So for instance; an image uploaded on the 15th of April 2017 will be stored under ``media/markdownx/2017/4/15/unique_name.png``.

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -101,7 +101,13 @@ class ImageForm(forms.Form):
         # Defining a universally unique name for the file
         # to be saved on the disk.
         unique_file_name = self.get_unique_file_name(file_name)
-        full_path = path.join(MARKDOWNX_MEDIA_PATH, unique_file_name)
+
+        if callable(MARKDOWNX_MEDIA_PATH):
+            base_dir = MARKDOWNX_MEDIA_PATH()
+        else:
+            base_dir = MARKDOWNX_MEDIA_PATH
+
+        full_path = path.join(base_dir, unique_file_name)
 
         if commit:
             default_storage.save(full_path, image)

--- a/markdownx/tests/tests.py
+++ b/markdownx/tests/tests.py
@@ -1,14 +1,24 @@
 import os
 import re
+from datetime import datetime
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
+
+from markdownx.forms import ImageForm
+
 try:
     from django.urls import reverse
-except ImportError:  # Djanago < 2.0
+except ImportError:  # Django < 2.0
     from django.core.urlresolvers import reverse
 
 
-class SimpleTest(TestCase):
+def _callable_media_path():
+    return datetime.now().strftime("%Y/%d/%m/")
 
+
+class SimpleTest(TestCase):
     def test_me(self):
         response = self.client.get('/testview/')
         self.assertEqual(response.status_code, 200)
@@ -33,3 +43,21 @@ class SimpleTest(TestCase):
                 os.remove(match[0])
         except OSError:
             pass
+
+    @patch("markdownx.forms.MARKDOWNX_MEDIA_PATH", _callable_media_path)
+    def test_callable_media_path(self):
+        test_file_path = "markdownx/tests/static/django-markdownx-preview.png"
+
+        with open(test_file_path, "rb") as fp:
+            form = ImageForm(
+                files={
+                    "image": SimpleUploadedFile(
+                        fp.name, fp.read(), content_type="image/png"
+                    )
+                }
+            )
+
+            self.assertTrue(form.is_valid())
+            image_data = form.save(commit=False)
+
+            self.assertTrue(_callable_media_path() in image_data.path)


### PR DESCRIPTION
If a user sets `MARKDOWNX_MEDIA_PATH = datetime.now().strftime('markdownx/%Y/%m/%d')` in their settings, the upload folder will remain the same until the settings are imported again when the server process is restarted, resulting in the active folder becoming out of step with the current date.

This PR adds support for defining `MARKDOWNX_MEDIA_PATH` as a callable, so that the folder name is always up to date.

`unittest.mock.patch` is used in the test here as the django settings test override methods are not compatible with the current way that `markdownx` imports settings.