### PR TITLE
corrected a spelling and updated the usage of path over url

### DIFF
--- a/docs/example/index.html
+++ b/docs/example/index.html
@@ -187,7 +187,7 @@ class MyForm(forms.Form):
 {{ form.media }}</code></pre>
 
 <h2 id="django-admin">Django Admin<a class="headerlink" href="#django-admin" title="Permanent link">&para;</a></h2>
-<p>When using included <code>MarkdowxModel</code> class in your models, just use <code>MarkdownxModelAdmin</code> in your <code>app/admin.py</code> as follows:</p>
+<p>When using included <code>MarkdownxModel</code> class in your models, just use <code>MarkdownxModelAdmin</code> in your <code>app/admin.py</code> as follows:</p>
 <pre class="highlight"><code class="language-python">from django.contrib import admin
 from markdownx.admin import MarkdownxModelAdmin
 from .models import MyModel

--- a/docs/getting_started/index.html
+++ b/docs/getting_started/index.html
@@ -147,15 +147,15 @@
 <p>Add MarkdownX URL patterns to your <code>urls.py</code>. You can do this using either of these methods depending on your style:</p>
 <pre class="highlight"><code class="language-python">urlpatterns = [
     # [...]
-    url(r'^markdownx/', include('markdownx.urls')),
+    path('markdownx/', include('markdownx.urls')),
 ]</code></pre>
 
 <p>or alternatively:</p>
-<pre class="highlight"><code class="language-python">from django.conf.urls import url, include
+<pre class="highlight"><code class="language-python">from django.urls import path, include
 from markdownx import urls as markdownx
 
 urlpatterns += [
-    url(r'^markdownx/', include(markdownx))
+    path('markdownx/', include(markdownx))
 ]</code></pre>
 
 <div class="admonition caution">


### PR DESCRIPTION
Was reading the documentation, saw a spelling mistake so reported!. Also the url function is likely to be deprecated so upgraded it to path.
See https://docs.djangoproject.com/en/3.0/ref/urls/#url