### PR TITLE
Fix links for python-markdown: point to github.io

### DIFF
--- a/docs-src/customization.md
+++ b/docs-src/customization.md
@@ -88,7 +88,7 @@ Default function that compiles markdown using defined extensions. Using custom f
 MARKDOWNX_MARKDOWNIFY_FUNCTION = 'markdownx.utils.markdownify'
 ```
 
-This function uses the [Markdown package](https://pythonhosted.org/Markdown/) for trans-compilation.
+This function uses the [Markdown package](https://python-markdown.github.io/) for trans-compilation.
 
 !!! note
 	The function name must be entered as string, and the relevant package must be installed and accessible to the current interpreter such that it can later be imported as and when needed. So ``markdownx.utils.markdownify`` essentially means ``from markdownx.utils import markdownify``.
@@ -117,9 +117,9 @@ This function uses the [Markdown package](https://pythonhosted.org/Markdown/) fo
 
 Default: empty ``list()``
 
-List of ``str()``. List of Markdown extensions that you would like to use. See [available extensions](https://pythonhosted.org/Markdown/extensions/index.html#officially-supported-extensions) in Markdown docs. For instance, the extension [extra](https://pythonhosted.org/Markdown/extensions/extra.html) enables features such as abbreviations, footnotes, tables and so on.
+List of ``str()``. List of Markdown extensions that you would like to use. See [available extensions](https://python-markdown.github.io/extensions/#officially-supported-extensions) in Markdown docs. For instance, the extension [extra](https://python-markdown.github.io/extensions/extra/) enables features such as abbreviations, footnotes, tables and so on.
 
-We recommend you read the documentation for the [Markdown package](https://pythonhosted.org/Markdown/), our default Markdown trans-compiler.
+We recommend you read the documentation for the [Markdown package](https://python-markdown.github.io/), our default Markdown trans-compiler.
 
 ```python
 MARKDOWNX_MARKDOWN_EXTENSIONS = [
@@ -132,7 +132,7 @@ MARKDOWNX_MARKDOWN_EXTENSIONS = [
 
 Default: empty ``dict()``
 
-Configuration object for used markdown extensions. See ``extension_configs`` in [Markdown docs](https://pythonhosted.org/Markdown/reference.html#markdown). Here is a general idea:
+Configuration object for used markdown extensions. See ``extension_configs`` in [Markdown docs](https://python-markdown.github.io/reference/#extension_configs). Here is a general idea:
 
 ```python
 MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS = {

--- a/docs/customization/index.html
+++ b/docs/customization/index.html
@@ -5,8 +5,8 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
-  
+
+
   <link rel="shortcut icon" href="../img/favicon.ico">
   <title>Customization - Django Markdownx</title>
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
@@ -14,28 +14,28 @@
   <link rel="stylesheet" href="../css/theme.css" type="text/css" />
   <link rel="stylesheet" href="../css/theme_extra.css" type="text/css" />
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css">
-  
+
   <script>
     // Current page data
     var mkdocs_page_name = "Customization";
     var mkdocs_page_input_path = "customization.md";
     var mkdocs_page_url = "/django-markdownx/customization/";
   </script>
-  
+
   <script src="../js/jquery-2.1.1.min.js" defer></script>
   <script src="../js/modernizr-2.8.3.min.js" defer></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/bash.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/django.min.js"></script>
-  <script>hljs.initHighlightingOnLoad();</script> 
-  
+  <script>hljs.initHighlightingOnLoad();</script>
+
 </head>
 
 <body class="wy-body-for-nav" role="document">
 
   <div class="wy-grid-for-nav">
 
-    
+
     <nav data-toggle="wy-nav-shift" class="wy-nav-side stickynav">
       <div class="wy-side-nav-search">
         <a href=".." class="icon icon-home"> Django Markdownx</a>
@@ -48,67 +48,67 @@
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
 	<ul class="current">
-	  
-          
+
+
             <li class="toctree-l1">
-		
+
     <a class="" href="..">Django MarkdownX</a>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../installation/">Installation</a>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../getting_started/">Getting Started</a>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../example/">Example</a>
 	    </li>
-          
+
             <li class="toctree-l1 current">
-		
+
     <a class="current" href="./">Customization</a>
     <ul class="subnav">
-            
+
     <li class="toctree-l2"><a href="#customization">Customization</a></li>
-    
+
         <ul>
-        
+
             <li><a class="toctree-l3" href="#general-ex-settings">General (ex. settings)</a></li>
-        
+
             <li><a class="toctree-l3" href="#settings">Settings</a></li>
-        
+
         </ul>
-    
+
 
     </ul>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../javascript/">JavaScript</a>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../translations/">Translations</a>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../contributions/">Contributions</a>
 	    </li>
-          
+
             <li class="toctree-l1">
-		
+
     <a class="" href="../license/">License</a>
 	    </li>
-          
+
         </ul>
       </div>
       &nbsp;
@@ -116,34 +116,34 @@
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 
-      
+
       <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
         <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
         <a href="..">Django Markdownx</a>
       </nav>
 
-      
+
       <div class="wy-nav-content">
         <div class="rst-content">
           <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
     <li><a href="..">Docs</a> &raquo;</li>
-    
-      
-    
+
+
+
     <li>Customization</li>
     <li class="wy-breadcrumbs-aside">
-      
+
         <a href="https://github.com/neutronX/django-markdownx/edit/master/docs/customization.md"
           class="icon icon-github"> Edit on GitHub</a>
-      
+
     </li>
   </ul>
   <hr/>
 </div>
           <div role="main">
             <div class="section">
-              
+
                 <h1 id="customization">Customization<a class="headerlink" href="#customization" title="Permanent link">&para;</a></h1>
 <h2 id="general-ex-settings">General (ex. settings)<a class="headerlink" href="#general-ex-settings" title="Permanent link">&para;</a></h2>
 <h3 id="widget">Widget<a class="headerlink" href="#widget" title="Permanent link">&para;</a></h3>
@@ -210,7 +210,7 @@ admin.site.register(MyModel, MyModelAdmin)</code></pre>
 <p>Default function that compiles markdown using defined extensions. Using custom function can allow you to pre-process or post-process markdown text. See below for more info.</p>
 <pre class="highlight"><code class="language-python">MARKDOWNX_MARKDOWNIFY_FUNCTION = 'markdownx.utils.markdownify'</code></pre>
 
-<p>This function uses the <a href="https://pythonhosted.org/Markdown/">Markdown package</a> for trans-compilation.</p>
+<p>This function uses the <a href="https://python-markdown.github.io/">Markdown package</a> for trans-compilation.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
 <p>The function name must be entered as string, and the relevant package must be installed and accessible to the current interpreter such that it can later be imported as and when needed. So <code>markdownx.utils.markdownify</code> essentially means <code>from markdownx.utils import markdownify</code>.</p>
@@ -236,15 +236,15 @@ def markdownify(content):
 </div>
 <h3 id="markdownx_markdown_extensions"><code>MARKDOWNX_MARKDOWN_EXTENSIONS</code><a class="headerlink" href="#markdownx_markdown_extensions" title="Permanent link">&para;</a></h3>
 <p>Default: empty <code>list()</code></p>
-<p>List of <code>str()</code>. List of Markdown extensions that you would like to use. See <a href="https://pythonhosted.org/Markdown/extensions/index.html#officially-supported-extensions">available extensions</a> in Markdown docs. For instance, the extension <a href="https://pythonhosted.org/Markdown/extensions/extra.html">extra</a> enables features such as abbreviations, footnotes, tables and so on.</p>
-<p>We recommend you read the documentation for the <a href="https://pythonhosted.org/Markdown/">Markdown package</a>, our default Markdown trans-compiler.</p>
+<p>List of <code>str()</code>. List of Markdown extensions that you would like to use. See <a href="https://python-markdown.github.io/extensions/#officially-supported-extensions">available extensions</a> in Markdown docs. For instance, the extension <a href="https://python-markdown.github.io/extensions/extra/">extra</a> enables features such as abbreviations, footnotes, tables and so on.</p>
+<p>We recommend you read the documentation for the <a href="https://python-markdown.github.io/">Markdown package</a>, our default Markdown trans-compiler.</p>
 <pre class="highlight"><code class="language-python">MARKDOWNX_MARKDOWN_EXTENSIONS = [
     'markdown.extensions.extra'
 ]</code></pre>
 
 <h3 id="markdownx_markdown_extension_configs"><code>MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS</code><a class="headerlink" href="#markdownx_markdown_extension_configs" title="Permanent link">&para;</a></h3>
 <p>Default: empty <code>dict()</code></p>
-<p>Configuration object for used markdown extensions. See <code>extension_configs</code> in <a href="https://pythonhosted.org/Markdown/reference.html#markdown">Markdown docs</a>. Here is a general idea:</p>
+<p>Configuration object for used markdown extensions. See <code>extension_configs</code> in <a href="https://python-markdown.github.io/reference/#extension_configs">Markdown docs</a>. Here is a general idea:</p>
 <pre class="highlight"><code class="language-python">MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS = {
     'extension_name_1': {
         'option_1': 'value_1'
@@ -366,31 +366,31 @@ MARKDOWNX_MEDIA_PATH = datetime.now().strftime('markdownx/%Y/%m/%d')</code></pre
 <p class="admonition-title">Attention</p>
 <p>Any values below 500 milliseconds is silently ignored and replaced.</p>
 </div>
-              
+
             </div>
           </div>
           <footer>
-  
+
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      
+
         <a href="../javascript/" class="btn btn-neutral float-right" title="JavaScript">Next <span class="icon icon-circle-arrow-right"></span></a>
-      
-      
+
+
         <a href="../example/" class="btn btn-neutral" title="Example"><span class="icon icon-circle-arrow-left"></span> Previous</a>
-      
+
     </div>
-  
+
 
   <hr/>
 
   <div role="contentinfo">
     <!-- Copyright etc -->
-    
+
   </div>
 
   Built with <a href="http://www.mkdocs.org">MkDocs</a> using a <a href="https://github.com/snide/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
 </footer>
-      
+
         </div>
       </div>
 
@@ -400,15 +400,15 @@ MARKDOWNX_MEDIA_PATH = datetime.now().strftime('markdownx/%Y/%m/%d')</code></pre
 
   <div class="rst-versions" role="note" style="cursor: pointer">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      
+
           <a href="https://github.com/neutronX/django-markdownx/" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
-      
-      
+
+
         <span><a href="../example/" style="color: #fcfcfc;">&laquo; Previous</a></span>
-      
-      
+
+
         <span style="margin-left: 15px"><a href="../javascript/" style="color: #fcfcfc">Next &raquo;</a></span>
-      
+
     </span>
 </div>
     <script>var base_url = '..';</script>


### PR DESCRIPTION
pythonhosted is gone, the documentation is now on GitHub Pages.