### PR TITLE
added 'MARKDOWNX_UPLOAD' to allow disabling media

### DIFF
--- a/markdownx/exceptions.py
+++ b/markdownx/exceptions.py
@@ -58,3 +58,16 @@ class MarkdownxImageUploadError(ValidationError):
                 'current': filesizeformat(current)
             }
         )
+
+    @classmethod
+    def upload_disabled(cls):
+        """
+        Media uploads to the server have been disabled
+
+        :return: Locale compatible version of the error with the following message:
+
+                 - No files have been uploaded.
+
+        :rtype: MarkdownxImageUploadError
+        """
+        return cls(_('Media uploads to the server are disabled.'))

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -15,7 +15,8 @@ from .settings import (
     MARKDOWNX_MEDIA_PATH,
     MARKDOWNX_UPLOAD_CONTENT_TYPES,
     MARKDOWNX_UPLOAD_MAX_SIZE,
-    MARKDOWNX_SVG_JAVASCRIPT_PROTECTION
+    MARKDOWNX_SVG_JAVASCRIPT_PROTECTION,
+    MARKDOWNX_UPLOAD,
 )
 
 
@@ -169,6 +170,9 @@ class ImageForm(forms.Form):
         # See comments in `self._error_templates` for
         # additional information on each error.
         # -----------------------------------------------
+        if not MARKDOWNX_UPLOAD:
+            raise MarkdownxImageUploadError.upload_disabled()
+
         if not upload:
             raise MarkdownxImageUploadError.not_uploaded()
 

--- a/markdownx/settings.py
+++ b/markdownx/settings.py
@@ -70,6 +70,8 @@ MARKDOWNX_IMAGE_MAX_SIZE = _mdx('IMAGE_MAX_SIZE', dict(size=(IM_WIDTH, IM_HEIGHT
 
 MARKDOWNX_SVG_JAVASCRIPT_PROTECTION = True
 
+MARKDOWNX_UPLOAD = _mdx('UPLOAD', True)
+
 
 # Editor
 # --------------------


### PR DESCRIPTION
Many users have a need to disallow users from uploading their own media to the server (neutronX#106). Prior django-markdownx did not natively support disabling media uploads. As a convienience feature I added the settings param ```MARKDOWNX_UPLOAD``` which defaults to True. When set to `False` it intercepts the post request in ImageForm and returns the ValidationError `'Media uploads to the server are disabled.'`