### PR TITLE
Detailed Error Messages when uploading (client-side)

### DIFF
--- a/markdownx/static/markdownx/js/markdownx.js
+++ b/markdownx/static/markdownx/js/markdownx.js
@@ -241,6 +241,7 @@
                         utils_1.triggerCustomEvent("markdownx.fileUploadEnd", properties.parent, [ response ]);
                     } else {
                         console.error(XHR_RESPONSE_ERROR, response);
+                        XHR_RESPONSE_ERROR = "*"+response.__all__+"*"
                         utils_1.triggerCustomEvent("markdownx.fileUploadError", properties.parent, [ response ]);
                         insertImage(XHR_RESPONSE_ERROR);
                     }


### PR DESCRIPTION
Previously, when uploading an erroneous file, the user would be prompted with the generic message `"Invalid response"` wether the file was too large, of the incorrect type, or just not allowed. By alerting the user to what is preventing the image from being sent. PR is a one line addition that replaces changes `XHR_RESPONSE_ERROR` to whatever the error message is that is passed in. For example, uploading an improper file type would tell the user `'File type is not supported.'` as opposed to `"Invalid response"`