### PR TITLE
Checking _editorIsResizable before calling updateHeight

### DIFF
--- a/static-src/markdownx/js/markdownx.ts
+++ b/static-src/markdownx/js/markdownx.ts
@@ -702,7 +702,8 @@ const MarkdownX = function (parent: HTMLElement, editor: HTMLTextAreaElement, pr
         xhr.success = (response: string): void => {
 
             properties.preview.innerHTML = response;
-            properties.editor = updateHeight(properties.editor);
+            properties.editor = properties._editorIsResizable ?
+              updateHeight(properties.editor) : properties.editor;
 
             triggerCustomEvent('markdownx.update', properties.parent, [response])
 


### PR DESCRIPTION
The `updateHeight` method is called whenever the HTML preview is updated, ignoring the `MARKDOWNX_EDITOR_RESIZABLE` option. This PR fixes it by checking `_editorIsResizable` before calling `updateHeight`.