### PR TITLE
fix: documentation <code> tags

### DIFF
--- a/docs/contributions/index.html
+++ b/docs/contributions/index.html
@@ -211,7 +211,7 @@ own <a href="https://www.vagrantup.com">Vagrant</a> and <a href="https://www.doc
 </tr>
 <tr>
 <td><code>--with-npm-settings</code></td>
-<td>Install npm installation environment, including `package.json<code>for front-end (TypeScript) development (requires</code>node.js<code>and</code>npm``).</td>
+<td>Install npm installation environment, including <code>package.json</code> for front-end (TypeScript) development (requires <code>node.js</code> and <code>npm</code>).</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
It fix render error in documentations's Contributions [Quick Reference][1] table, in `--with-npm-settings` argument

  [1]: https://neutronx.github.io/django-markdownx/contributions/#quick-reference