### PR TITLE
replace a removed method is_ajax() in Django 4.0 with an alternative

### DIFF
--- a/markdownx/views.py
+++ b/markdownx/views.py
@@ -45,7 +45,7 @@ class ImageUploadView(BaseFormView):
                  and the default response for HTTP requests.
         :rtype: django.http.JsonResponse, django.http.HttpResponse
         """
-        if self.request.is_ajax():
+        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return JsonResponse(form.errors, status=400)
 
         response = super(ImageUploadView, self).form_invalid(form)


### PR DESCRIPTION
`form_valid()` has already been fixed as below: https://github.com/neutronX/django-markdownx/blob/52c9a1e6705b232b5c375574c68840b83cca8594/markdownx/views.py#L76

But `form_invalid()` hasn't yet. The patch fixes it.

ref: #221