### PR TITLE
[Django 4.0] request.is_ajax is deprecated since 3.1 and removed in 4.0

### DIFF
--- a/markdownx/views.py
+++ b/markdownx/views.py
@@ -45,7 +45,7 @@ class ImageUploadView(BaseFormView):
                  and the default response for HTTP requests.
         :rtype: django.http.JsonResponse, django.http.HttpResponse
         """
-        if self.request.is_ajax():
+        if self.request.accepts("application/json"):
             return JsonResponse(form.errors, status=400)
 
         response = super(ImageUploadView, self).form_invalid(form)


### PR DESCRIPTION
Django reference: https://docs.djangoproject.com/en/4.0/releases/3.1/#id2