### PR TITLE
give MARKDOWNX_IMAGE_MAX_SIZE to save() method to ensure quality parameter is used when saving image

### DIFF
--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -132,7 +132,7 @@ class ImageForm(forms.Form):
         """
         thumb_io = BytesIO()
         preped_image = scale_and_crop(image, **MARKDOWNX_IMAGE_MAX_SIZE)
-        preped_image.save(thumb_io, extension)
+        preped_image.save(thumb_io, extension, **MARKDOWNX_IMAGE_MAX_SIZE)
         thumb_io.seek(0, SEEK_END)
         return thumb_io
 


### PR DESCRIPTION
In the current code the quality param from the settings is only set to the meta data of the image, but it is not actually used when saving the image.
Due to this the quality param is basically ignored. To make the image be saved with the desired quality the quality param needs to be set on the save method as well.