### PR TITLE
add MARKDOWNX_SKIP_RESIZE to allow for animated gif-upload

### DIFF
--- a/docs-src/customization.md
+++ b/docs-src/customization.md
@@ -66,6 +66,7 @@ You may place any of the variables outlined in this page in your `settings.py`, 
 * [`MARKDOWNX_MEDIA_PATH`](#markdownx_media_path)
 * [`MARKDOWNX_UPLOAD_MAX_SIZE`](#markdownx_upload_max_size)
 * [`MARKDOWNX_UPLOAD_CONTENT_TYPES`](#markdownx_upload_content_types)
+* [`MARKDOWNX_SKIP_RESIZE`](#markdownx_skip_resize)
 * [`MARKDOWNX_IMAGE_MAX_SIZE`](#markdownx_image_max_size)
 * [`MARKDOWNX_SVG_JAVASCRIPT_PROTECTION`](#markdownx_svg_javascript_protection)
 * [`MARKDOWNX_EDITOR_RESIZABLE`](#markdownx_editor_resizable)
@@ -198,12 +199,22 @@ MARKDOWNX_UPLOAD_MAX_SIZE = 50 * 1024 * 1024
 
 ### `MARKDOWNX_UPLOAD_CONTENT_TYPES`
 
-Default: `['image/jpeg', 'image/png', 'image/svg+xml']`
+Default: `['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']`
 
 Image formats that the user is permitted to upload. Enable / disable support for different image formats.
 
 ```python
-MARKDOWNX_UPLOAD_CONTENT_TYPES = ['image/jpeg', 'image/png', 'image/svg+xml']
+MARKDOWNX_UPLOAD_CONTENT_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']
+```
+
+### `MARKDOWNX_SKIP_RESIZE`
+
+Default: `['image/svg+xml', 'image/gif']`
+
+Image formats that should not be resized automatically. The default value honors that resizing an SVG does not make sense and that PIL does not support GIF animation.
+
+```python
+MARKDOWNX_SKIP_RESIZE = ['image/svg+xml', 'image/gif']
 ```
 
 ### `MARKDOWNX_IMAGE_MAX_SIZE`

--- a/markdownx/forms.py
+++ b/markdownx/forms.py
@@ -12,6 +12,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from .exceptions import MarkdownxImageUploadError
 from .settings import MARKDOWNX_IMAGE_MAX_SIZE
 from .settings import MARKDOWNX_MEDIA_PATH
+from .settings import MARKDOWNX_SKIP_RESIZE
 from .settings import MARKDOWNX_SVG_JAVASCRIPT_PROTECTION
 from .settings import MARKDOWNX_UPLOAD_CONTENT_TYPES
 from .settings import MARKDOWNX_UPLOAD_MAX_SIZE
@@ -34,9 +35,9 @@ class ImageForm(forms.Form):
         """
         Saves the uploaded image in the designated location.
 
-        If image type is not SVG, a byteIO of image content_type is created and
-        subsequently save; otherwise, the SVG is saved in its existing ``charset``
-        as an ``image/svg+xml``.
+        If image type is not liste as ``MARKDOWNX_SKIP_RESIZE``, a byteIO of image
+        content_type is created and subsequently save; otherwise, the image is saved
+        in its existing ``charset`` with its existing mime type.
 
         *Note*: The dimension of image files (excluding SVG) are set using ``PIL``.
 
@@ -53,10 +54,10 @@ class ImageForm(forms.Form):
         image_extension = content_type.split('/')[-1].upper()
         image_size = image.size
 
-        if content_type.lower() != self._SVG_TYPE:
+        if content_type.lower() not in MARKDOWNX_SKIP_RESIZE:
             # Processing the raster graphic image.
-            # Note that vector graphics in SVG format
-            # do not require additional processing and
+            # Note that some graphics do not require (or enable)
+            # additional processing (such as GIF or SVG) and
             # may be stored as uploaded.
             image = self._process_raster(image, image_extension)
             image_size = image.tell()

--- a/markdownx/settings.py
+++ b/markdownx/settings.py
@@ -8,7 +8,8 @@ from django.utils.translation import gettext_lazy as _
 # ------------------------------------------------------------------
 
 FIFTY_MEGABYTES = 50 * 1024 * 1024
-VALID_CONTENT_TYPES = 'image/jpeg', 'image/png', 'image/svg+xml'
+VALID_CONTENT_TYPES = 'image/jpeg', 'image/png', 'image/gif', 'image/svg+xml'
+SVG_AND_GIF_TYPES = 'image/svg+xml', 'image/gif'
 NINETY_DPI = 90
 IM_WIDTH = 500
 IM_HEIGHT = 500
@@ -66,6 +67,8 @@ MARKDOWNX_UPLOAD_CONTENT_TYPES = _mdx('UPLOAD_CONTENT_TYPES', VALID_CONTENT_TYPE
 MARKDOWNX_IMAGE_MAX_SIZE = _mdx('IMAGE_MAX_SIZE', dict(size=(IM_WIDTH, IM_HEIGHT), quality=NINETY_DPI))
 
 MARKDOWNX_SVG_JAVASCRIPT_PROTECTION = True
+
+MARKDOWNX_SKIP_RESIZE = _mdx('SKIP_RESIZE', SVG_AND_GIF_TYPES)
 
 # Editor
 # --------------------


### PR DESCRIPTION
This PR addresses an issue discussed in #24, where @jaywink [proposed a change](https://github.com/jaywink/django-markdownx/commit/e42748b9e411550ba4a70287cc006824a7199887) to skip processing of gif-files by PIL, as PIL does not support animated gifs correctly.

This PR introduces the option `MARKDOWNX_SKIP_RESIZE` which contains content types where no resize should be done and defaults this to svg and gif.